### PR TITLE
Replace payload string to unsafe.Pointer

### DIFF
--- a/netradix.go
+++ b/netradix.go
@@ -134,7 +134,7 @@ func (rtree *NetRadixTree) Remove(addr string) error {
 
 	node := C.radix_search_exact(rtree.tree, &prefix)
 	if node != nil {
-		C.free(unsafe.Pointer(node.data))
+		//C.free(unsafe.Pointer(node.data))
 		C.radix_remove(rtree.tree, node)
 	}
 


### PR DESCRIPTION
``` golang
For example:
package main

import (
    "fmt"
    "github.com/thekvs/go-net-radix"
    "log"
    "unsafe"
)

type RateLimit struct {
    rate   int
    perSec int
}

func main() {
    rateLimits := make([]*RateLimit, 0, 0)

    rtree, err := netradix.NewNetRadixTree()
    if err != nil {
        panic(err)
    }

    rateLimit := &RateLimit{rate: 1000, perSec: 60}
    rateLimits = append(rateLimits, rateLimit)
    if err = rtree.Add("217.72.192.0/20", unsafe.Pointer(rateLimit)); err != nil {
        log.Fatal(err)
    }
    found, ptr, err := rtree.SearchBest("217.72.192.1")
    if err != nil {
        log.Fatal(err)
    }
    if found {
        rateLimit := (*RateLimit)(ptr)
        fmt.Printf("found: rate = %d, perSec = %d\n", rateLimit.rate, rateLimit.perSec)
    }

}
```
